### PR TITLE
Correct path to main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "amcharts3",
   "version": "1.7.0",
   "description": "JavaScript Charts V3",
-  "main": "amcharts.js",
+  "main": "amcharts/amcharts.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/amcharts/amcharts3.git"


### PR DESCRIPTION
When you use `require('amcharts3')`, it pulls in the `main` file from package.json. This is the correct path to that file.