### PR TITLE
Correct bower file path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   ],
   "description": "JavaScript Charts V3",
   "main": [
-    "js/amcharts.js"
+    "amcharts/amcharts.js"
   ],
   "keywords": [
     "amcharts",


### PR DESCRIPTION
The path to amcharts.js is not correct, and this causes problems when using tools like wiredep. This now matches what is in package.json for NPM.