### PR TITLE
Fix SVG lens icons

### DIFF
--- a/amcharts/images/lens.svg
+++ b/amcharts/images/lens.svg
@@ -2,6 +2,6 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="19px" height="19px" viewBox="0 0 19 19">
   <circle cx="8.5" cy="8.5" r="7.5" stroke="#000000" stroke-width="1.5" fill-opacity="0"/>
-  <line x1="5" y1="9" x2="12" y2="9" stroke="#000000" stroke-width="1.5"/>
+  <line x1="5" y1="8.5" x2="12" y2="8.5" stroke="#000000" stroke-width="1.5"/>
   <line x1="14" y1="14" x2="19" y2="19" stroke="#000000" stroke-width="1.5"/>
 </svg>

--- a/amcharts/images/lensWhite.svg
+++ b/amcharts/images/lensWhite.svg
@@ -2,6 +2,6 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="19px" height="19px" viewBox="0 0 19 19">
   <circle cx="8.5" cy="8.5" r="7.5" stroke="#ffffff" stroke-width="1.5" fill-opacity="0"/>
-  <line x1="5" y1="9" x2="12" y2="9" stroke="#ffffff" stroke-width="1.5"/>
+  <line x1="5" y1="8.5" x2="12" y2="8.5" stroke="#ffffff" stroke-width="1.5"/>
   <line x1="14" y1="14" x2="19" y2="19" stroke="#ffffff" stroke-width="1.5"/>
 </svg>


### PR DESCRIPTION
I noticed that SVG icons for lenses doesn't look right. The minus sign inside isn't centered, while in PNG versions it is. amCharts3 are beautiful, but this little flaw irks me, so I decided to fix it.

![screen shot 2015-10-16 at 20 24 19](https://cloud.githubusercontent.com/assets/192247/10544344/456e3728-743c-11e5-879d-e50f756e9b14.png)

Fixed white version as well.
