### PR TITLE
Update npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ support staff, so your questions might take longer to respond to here.
 ### Using npm
 
 ```
-npm install amcharts/amcharts3
+npm install amcharts3
 ```
 
 ### Using bower


### PR DESCRIPTION
The npm install command documented inside the readme doesn't point to the npm version of the lib, it points to the github repo.

When I execute
`npm install amcharts/amcharts3 --save`
I get the following dependency added to my `package.json`
`"amcharts3": "github:amcharts/amcharts3",`

This could be easily fixed doing 
`npm install amcharts3 --save`
Then I will get
`"amcharts3": "^3.21.12",`